### PR TITLE
lock python to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.10
 
 COPY . ./usr/app/src
 WORKDIR /usr/app/src


### PR DESCRIPTION
solves #1 (Docker image build fails for python > 3.10) caused by later versions of python not shipping with dependencies needed to built some requirements (didnt work for me)

3.10 builds successfully (works for me)